### PR TITLE
Add templated classes visitation

### DIFF
--- a/include/visit_struct/visit_struct.hpp
+++ b/include/visit_struct/visit_struct.hpp
@@ -687,6 +687,9 @@ static VISIT_STRUCT_CONSTEXPR const int max_visitable_members = 69;
     type_at(std::integral_constant<int, fields_enum::MEMBER_NAME>) ->                              \
       visit_struct::type_c<decltype(this_type::MEMBER_NAME)>;
 
+#define VISIT_STRUCT_UNPACK_PARENS(X) VISIT_STRUCT_UNPACK_PARENS_ X
+
+#define VISIT_STRUCT_UNPACK_PARENS_(...) __VA_ARGS__
 
 // This macro specializes the trait, provides "apply" method which does the work.
 // Below, template parameter S should always be the same as STRUCT_NAME modulo const and reference.
@@ -701,126 +704,81 @@ static VISIT_STRUCT_CONSTEXPR const int max_visitable_members = 69;
 //          values, and have a new specialization for each member. But, specializations can only
 //          be made at namespace scope. So to keep things tidy and contained within this trait,
 //          we use tag dispatch with std::integral_constant<int> instead.
+#define VISITABLE_STRUCT_IMPL(TPARAMS, FULL_TYPE, STRUCT_NAME, CONTEXT, ...)                       \
+namespace visit_struct {                                                                           \
+namespace traits {                                                                                 \
+                                                                                                   \
+template <VISIT_STRUCT_UNPACK_PARENS(TPARAMS)>                                                     \
+struct visitable<VISIT_STRUCT_UNPACK_PARENS(FULL_TYPE), CONTEXT> {                                 \
+                                                                                                   \
+  using this_type = VISIT_STRUCT_UNPACK_PARENS(FULL_TYPE);                                         \
+                                                                                                   \
+  static VISIT_STRUCT_CONSTEXPR auto get_name()                                                    \
+    -> decltype(#STRUCT_NAME) {                                                                    \
+    return #STRUCT_NAME;                                                                           \
+  }                                                                                                \
+                                                                                                   \
+  static VISIT_STRUCT_CONSTEXPR const std::size_t field_count = 0                                  \
+    VISIT_STRUCT_PP_MAP(VISIT_STRUCT_FIELD_COUNT, __VA_ARGS__);                                    \
+                                                                                                   \
+  template <typename V, typename S>                                                                \
+  VISIT_STRUCT_CXX14_CONSTEXPR static void apply(V && visitor, S && struct_instance)               \
+  {                                                                                                \
+    VISIT_STRUCT_PP_MAP(VISIT_STRUCT_MEMBER_HELPER, __VA_ARGS__)                                   \
+  }                                                                                                \
+                                                                                                   \
+  template <typename V, typename S1, typename S2>                                                  \
+  VISIT_STRUCT_CXX14_CONSTEXPR static void apply(V && visitor, S1 && s1, S2 && s2)                 \
+  {                                                                                                \
+    VISIT_STRUCT_PP_MAP(VISIT_STRUCT_MEMBER_HELPER_PAIR, __VA_ARGS__)                              \
+  }                                                                                                \
+                                                                                                   \
+  template <typename V>                                                                            \
+  VISIT_STRUCT_CXX14_CONSTEXPR static void visit_pointers(V && visitor)                            \
+  {                                                                                                \
+    VISIT_STRUCT_PP_MAP(VISIT_STRUCT_MEMBER_HELPER_PTR, __VA_ARGS__)                               \
+  }                                                                                                \
+                                                                                                   \
+  template <typename V>                                                                            \
+  VISIT_STRUCT_CXX14_CONSTEXPR static void visit_types(V && visitor)                               \
+  {                                                                                                \
+    VISIT_STRUCT_PP_MAP(VISIT_STRUCT_MEMBER_HELPER_TYPE, __VA_ARGS__)                              \
+  }                                                                                                \
+                                                                                                   \
+  template <typename V>                                                                            \
+  VISIT_STRUCT_CXX14_CONSTEXPR static void visit_accessors(V && visitor)                           \
+  {                                                                                                \
+    VISIT_STRUCT_PP_MAP(VISIT_STRUCT_MEMBER_HELPER_ACC, __VA_ARGS__)                               \
+  }                                                                                                \
+                                                                                                   \
+  struct fields_enum {                                                                             \
+    enum index { __VA_ARGS__ };                                                                    \
+  };                                                                                               \
+                                                                                                   \
+  VISIT_STRUCT_PP_MAP(VISIT_STRUCT_MAKE_GETTERS, __VA_ARGS__)                                      \
+                                                                                                   \
+  static VISIT_STRUCT_CONSTEXPR const bool value = true;                                           \
+};                                                                                                 \
+                                                                                                   \
+}                                                                                                  \
+}                                                                                                  \
+static_assert(true, "")
 
 #define VISITABLE_STRUCT(STRUCT_NAME, ...)                                                         \
-namespace visit_struct {                                                                           \
-namespace traits {                                                                                 \
-                                                                                                   \
-template <>                                                                                        \
-struct visitable<STRUCT_NAME, void> {                                                              \
-                                                                                                   \
-  using this_type = STRUCT_NAME;                                                                   \
-                                                                                                   \
-  static VISIT_STRUCT_CONSTEXPR auto get_name()                                                    \
-    -> decltype(#STRUCT_NAME) {                                                                    \
-    return #STRUCT_NAME;                                                                           \
-  }                                                                                                \
-                                                                                                   \
-  static VISIT_STRUCT_CONSTEXPR const std::size_t field_count = 0                                  \
-    VISIT_STRUCT_PP_MAP(VISIT_STRUCT_FIELD_COUNT, __VA_ARGS__);                                    \
-                                                                                                   \
-  template <typename V, typename S>                                                                \
-  VISIT_STRUCT_CXX14_CONSTEXPR static void apply(V && visitor, S && struct_instance)               \
-  {                                                                                                \
-    VISIT_STRUCT_PP_MAP(VISIT_STRUCT_MEMBER_HELPER, __VA_ARGS__)                                   \
-  }                                                                                                \
-                                                                                                   \
-  template <typename V, typename S1, typename S2>                                                  \
-  VISIT_STRUCT_CXX14_CONSTEXPR static void apply(V && visitor, S1 && s1, S2 && s2)                 \
-  {                                                                                                \
-    VISIT_STRUCT_PP_MAP(VISIT_STRUCT_MEMBER_HELPER_PAIR, __VA_ARGS__)                              \
-  }                                                                                                \
-                                                                                                   \
-  template <typename V>                                                                            \
-  VISIT_STRUCT_CXX14_CONSTEXPR static void visit_pointers(V && visitor)                            \
-  {                                                                                                \
-    VISIT_STRUCT_PP_MAP(VISIT_STRUCT_MEMBER_HELPER_PTR, __VA_ARGS__)                               \
-  }                                                                                                \
-                                                                                                   \
-  template <typename V>                                                                            \
-  VISIT_STRUCT_CXX14_CONSTEXPR static void visit_types(V && visitor)                               \
-  {                                                                                                \
-    VISIT_STRUCT_PP_MAP(VISIT_STRUCT_MEMBER_HELPER_TYPE, __VA_ARGS__)                              \
-  }                                                                                                \
-                                                                                                   \
-  template <typename V>                                                                            \
-  VISIT_STRUCT_CXX14_CONSTEXPR static void visit_accessors(V && visitor)                           \
-  {                                                                                                \
-    VISIT_STRUCT_PP_MAP(VISIT_STRUCT_MEMBER_HELPER_ACC, __VA_ARGS__)                               \
-  }                                                                                                \
-                                                                                                   \
-  struct fields_enum {                                                                             \
-    enum index { __VA_ARGS__ };                                                                    \
-  };                                                                                               \
-                                                                                                   \
-  VISIT_STRUCT_PP_MAP(VISIT_STRUCT_MAKE_GETTERS, __VA_ARGS__)                                      \
-                                                                                                   \
-  static VISIT_STRUCT_CONSTEXPR const bool value = true;                                           \
-};                                                                                                 \
-                                                                                                   \
-}                                                                                                  \
-}                                                                                                  \
-static_assert(true, "")
+  VISITABLE_STRUCT_IMPL((), (STRUCT_NAME), STRUCT_NAME, void, __VA_ARGS__)
 
 #define VISITABLE_STRUCT_IN_CONTEXT(CONTEXT, STRUCT_NAME, ...)                                     \
-namespace visit_struct {                                                                           \
-namespace traits {                                                                                 \
-                                                                                                   \
-template <>                                                                                        \
-struct visitable<STRUCT_NAME, CONTEXT> {                                                           \
-                                                                                                   \
-  using this_type = STRUCT_NAME;                                                                   \
-                                                                                                   \
-  static VISIT_STRUCT_CONSTEXPR auto get_name()                                                    \
-    -> decltype(#STRUCT_NAME) {                                                                    \
-    return #STRUCT_NAME;                                                                           \
-  }                                                                                                \
-                                                                                                   \
-  static VISIT_STRUCT_CONSTEXPR const std::size_t field_count = 0                                  \
-    VISIT_STRUCT_PP_MAP(VISIT_STRUCT_FIELD_COUNT, __VA_ARGS__);                                    \
-                                                                                                   \
-  template <typename V, typename S>                                                                \
-  VISIT_STRUCT_CXX14_CONSTEXPR static void apply(V && visitor, S && struct_instance)               \
-  {                                                                                                \
-    VISIT_STRUCT_PP_MAP(VISIT_STRUCT_MEMBER_HELPER, __VA_ARGS__)                                   \
-  }                                                                                                \
-                                                                                                   \
-  template <typename V, typename S1, typename S2>                                                  \
-  VISIT_STRUCT_CXX14_CONSTEXPR static void apply(V && visitor, S1 && s1, S2 && s2)                 \
-  {                                                                                                \
-    VISIT_STRUCT_PP_MAP(VISIT_STRUCT_MEMBER_HELPER_PAIR, __VA_ARGS__)                              \
-  }                                                                                                \
-                                                                                                   \
-  template <typename V>                                                                            \
-  VISIT_STRUCT_CXX14_CONSTEXPR static void visit_pointers(V && visitor)                            \
-  {                                                                                                \
-    VISIT_STRUCT_PP_MAP(VISIT_STRUCT_MEMBER_HELPER_PTR, __VA_ARGS__)                               \
-  }                                                                                                \
-                                                                                                   \
-  template <typename V>                                                                            \
-  VISIT_STRUCT_CXX14_CONSTEXPR static void visit_types(V && visitor)                               \
-  {                                                                                                \
-    VISIT_STRUCT_PP_MAP(VISIT_STRUCT_MEMBER_HELPER_TYPE, __VA_ARGS__)                              \
-  }                                                                                                \
-                                                                                                   \
-  template <typename V>                                                                            \
-  VISIT_STRUCT_CXX14_CONSTEXPR static void visit_accessors(V && visitor)                           \
-  {                                                                                                \
-    VISIT_STRUCT_PP_MAP(VISIT_STRUCT_MEMBER_HELPER_ACC, __VA_ARGS__)                               \
-  }                                                                                                \
-                                                                                                   \
-  struct fields_enum {                                                                             \
-    enum index { __VA_ARGS__ };                                                                    \
-  };                                                                                               \
-                                                                                                   \
-  VISIT_STRUCT_PP_MAP(VISIT_STRUCT_MAKE_GETTERS, __VA_ARGS__)                                      \
-                                                                                                   \
-  static VISIT_STRUCT_CONSTEXPR const bool value = true;                                           \
-};                                                                                                 \
-                                                                                                   \
-}                                                                                                  \
-}                                                                                                  \
-static_assert(true, "")
+  VISITABLE_STRUCT_IMPL((), (STRUCT_NAME), STRUCT_NAME, CONTEXT, __VA_ARGS__)
+
+#define VISITABLE_TEMPLATE_STRUCT(TPARAMS, STRUCT_NAME, TARGS, ...)                                \
+  VISITABLE_STRUCT_IMPL(TPARAMS,                                                                   \
+    (STRUCT_NAME<VISIT_STRUCT_UNPACK_PARENS(TARGS)>),                                              \
+    STRUCT_NAME, void, __VA_ARGS__)
+
+#define VISITABLE_TEMPLATE_STRUCT_IN_CONTEXT(CONTEXT, TPARAMS, STRUCT_NAME, TARGS, ...)            \
+  VISITABLE_STRUCT_IMPL(TPARAMS,                                                                   \
+    (STRUCT_NAME<VISIT_STRUCT_UNPACK_PARENS(TARGS)>),                                              \
+    STRUCT_NAME, CONTEXT, __VA_ARGS__)
 
 } // end namespace visit_struct
 

--- a/test_visit_struct.cpp
+++ b/test_visit_struct.cpp
@@ -42,6 +42,26 @@ VISITABLE_STRUCT_IN_CONTEXT(MyContext, test_struct_two, b, i, d, s);
 static_assert(visit_struct::traits::is_visitable<test_struct_two, MyContext>::value, "WTF");
 static_assert(visit_struct::context<MyContext>::field_count<test_struct_two>() == 4, "WTF");
 
+// templated class
+template<typename A, typename B, typename C, typename D>
+struct templated_struct {
+  A a;
+  B b;
+  C c;
+  D d;
+};
+
+VISITABLE_TEMPLATE_STRUCT((typename A, typename B, typename C, typename D), templated_struct, (A, B, C, D), a, b, c);
+// Note that D is not registered
+
+static_assert(visit_struct::traits::is_visitable<templated_struct<int, float, std::string, double>>::value, "WTF");
+static_assert(visit_struct::field_count<templated_struct<int, float, std::string, double>>() == 3, "WTF");
+
+VISITABLE_TEMPLATE_STRUCT_IN_CONTEXT(MyContext, (typename A, typename B, typename C, typename D), templated_struct, (A, B, C, D), d, c, b, a);
+
+static_assert(visit_struct::traits::is_visitable<templated_struct<int, float, std::string, double>, MyContext>::value, "WTF");
+static_assert(visit_struct::context<MyContext>::field_count<templated_struct<int, float, std::string, double>>() == 4, "WTF");
+
 /***
  * Test visitors
  */
@@ -369,6 +389,44 @@ int main() {
     assert(std::string("test_struct_two") == visit_struct::get_name(s));
     assert(std::string("test_struct_two") == visit_struct::get_name(t));
     assert(std::string("test_struct_two") == visit_struct::get_name<test_struct_two>());
+  }
+
+  // template class
+  {
+    templated_struct<int, float, std::string, double> s{ 5, 7.5f, "asdf", -1.0 };
+
+	debug_print(s);
+
+    assert(visit_struct::get<0>(s) == 5);
+    assert(visit_struct::get<1>(s) == 7.5f);
+    assert(visit_struct::get<2>(s) == "asdf");
+    assert(visit_struct::get_name<0>(s) == std::string{"a"});
+    assert(visit_struct::get_name<1>(s) == std::string{"b"});
+    assert(visit_struct::get_name<2>(s) == std::string{"c"});
+
+    test_visitor_one vis1;
+    visit_struct::apply_visitor(vis1, s);
+
+    assert(vis1.result.size() == 3);
+    assert(vis1.result[0].first == "a");
+    assert(vis1.result[0].second == "5");
+    assert(vis1.result[1].first == "b");
+    assert(vis1.result[1].second == "7.500000");
+    assert(vis1.result[2].first == "c");
+    assert(vis1.result[2].second == "asdf");
+
+    test_visitor_two vis2;
+    visit_struct::apply_visitor(vis2, s);
+
+    assert(vis2.result.size() == 3);
+    assert(vis2.result[0].second == &s.a);
+    assert(vis2.result[1].second == &s.b);
+    assert(vis2.result[2].second == &s.c);
+
+    // test get_name
+    assert(std::string("templated_struct") == visit_struct::get_name(s));
+    assert((std::string("templated_struct") == visit_struct::get_name<templated_struct<int, float, std::string, double>>()));
+
   }
 
   // Test move semantics


### PR DESCRIPTION
I've been using the visit struct library for quite some time in my own libraries [ImReflect](https://github.com/Sven-vh/ImReflect) and [JsonReflect](https://github.com/Sven-vh/JsonReflect). Today I ran into the need of visiting templated structs.

I saw there was already an issue related to this #30 with the idea of:
```cpp
template<typename F, typename G>
VISITABLE_TEMPLATE_STRUCT(MyStruct<F, G<F>>, a, b, c, d);
```

This proposed idea won't work, I think, because the first lines of the ``VISITABLE_STRUCT`` macro are the namespaces. So you'll get:
```cpp
template<typename F, typename G>
namespace visit_struct {
namespace traits {
```

Instead, I made a macro where you need to include the template parameters:
```cpp
#define VISITABLE_TEMPLATE_STRUCT(TPARAMS, STRUCT_NAME, TARGS, ...)
```
Usage:
```cpp
template<typename A, typename B, typename C, typename D>
struct templated_struct {
    A a;
    B b;
    C c;
    D d;
};

VISITABLE_TEMPLATE_STRUCT((typename A, typename B, typename C, typename D), templated_struct, (A, B, C, D), a, b, c);
```

To be fair, it is a bit bulky, but it fully works!

I also cleaned up the ``VISITABLE_STRUCT`` and ``VISITABLE_STRUCT_IN_CONTEXT`` macros. Instead of both having their own implementation, they now reuse the new ``VISITABLE_STRUCT_IMPL`` macro. 

With the template implementation, we now have 4 macros:
- ``VISITABLE_STRUCT``
- ``VISITABLE_STRUCT_IN_CONTEXT``
- ``VISITABLE_TEMPLATE_STRUCT`` (new)
- ``VISITABLE_TEMPLATE_STRUCT_IN_CONTEXT`` (new)

I also included some tests to account for this new macro!

This is one of my first PR on someone else's repo, so let me know if I made any mistakes or need to change something.